### PR TITLE
Add FQN for atomicfu gradle plugin

### DIFF
--- a/atomicfu-gradle-plugin/src/main/resources/META-INF/gradle-plugins/org.jetbrains.kotlin.plugin.atomicfu.properties
+++ b/atomicfu-gradle-plugin/src/main/resources/META-INF/gradle-plugins/org.jetbrains.kotlin.plugin.atomicfu.properties
@@ -1,0 +1,1 @@
+implementation-class=kotlinx.atomicfu.plugin.gradle.AtomicFUGradlePlugin


### PR DESCRIPTION
To be convenient with default Kotlin gradle plugin and Gradle's naming conventions for plugins I suggest to add full-qualified name for atomicfu plugin.
It can be used in the following ways:
```kotlin
plugins {
  id("org.jetbrains.kotlin.jvm") version "${kotlin_version}"
  id("org.jetbrains.kotlin.plugin.atomicfu") version "${atomicfu_version}"
}
```
Or via Gradle Kotlin DSL extensions:
```kotlin
plugins {
  kotlin("jvm") version "${kotlin_version}"
  kotlin("plugin.atomicfu") version "${atomicfu_version}"
}
```
I choose the prefix `org.jetbrains.kotlin.plugin` similarly to `org.jetbrains.kotlin.plugin.serialization` from `kotlinx.serialization`